### PR TITLE
Generate activation link with user pk instead of username

### DIFF
--- a/templates/users/registration/account_activation_email.html
+++ b/templates/users/registration/account_activation_email.html
@@ -3,6 +3,6 @@ Hello, {{ user.user_name }}!
 
 Your account has been successfully created. Please click the link below to activate your account.
 
-http://{{ domain }}{% url 'users:activate' uidb64=user token=token %}
+http://{{ domain }}{% url 'users:activate' uidb64=uid token=token %}
 
 {% endautoescape %}


### PR DESCRIPTION
account_activate requires the pk of the user model instead of its username.